### PR TITLE
Add comprehensive public gallery and flow viewer system

### DIFF
--- a/src/components/FlowsGallery.tsx
+++ b/src/components/FlowsGallery.tsx
@@ -87,9 +87,9 @@ export function FlowsGallery({ onLoadFlow, onPageChange }: FlowsGalleryProps) {
   }
 
   const shareFlow = (flow: Flow) => {
-    const shareUrl = `${window.location.origin}${window.location.pathname}?shared=${flow.id}`
+    const shareUrl = `${window.location.origin}/flow/${flow.id}`
     navigator.clipboard.writeText(shareUrl).then(() => {
-      showToast('Shareable link copied to clipboard!', 'success')
+      showToast('Public flow link copied to clipboard!', 'success')
     }).catch(() => {
       showToast('Failed to copy to clipboard. Check console for link.', 'error')
       console.log('Share link:', shareUrl)

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,8 +3,8 @@ import { useAuth } from './AuthProvider'
 import { LoginModal } from './LoginModal'
 
 interface HeaderProps {
-  currentPage: 'builder' | 'gallery'
-  onPageChange: (page: 'builder' | 'gallery') => void
+  currentPage: 'builder' | 'gallery' | 'public-gallery' | 'flow-viewer'
+  onPageChange: (page: 'builder' | 'gallery' | 'public-gallery') => void
 }
 
 export function Header({ currentPage, onPageChange }: HeaderProps) {
@@ -103,6 +103,16 @@ export function Header({ currentPage, onPageChange }: HeaderProps) {
             >
               Flow builder
             </button>
+            <button 
+              onClick={() => onPageChange('public-gallery')}
+              className={`px-3 py-2 rounded-lg font-medium text-sm transition-colors min-h-[40px] flex items-center ${
+                currentPage === 'public-gallery' || currentPage === 'flow-viewer'
+                  ? 'bg-blue-100 text-blue-700 border border-blue-200' 
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200 hover:text-gray-900'
+              }`}
+            >
+              Gallery
+            </button>
             {user && (
               <button 
                 onClick={() => onPageChange('gallery')}
@@ -138,6 +148,16 @@ export function Header({ currentPage, onPageChange }: HeaderProps) {
                 }`}
               >
                 Flow builder
+              </button>
+              <button 
+                onClick={() => onPageChange('public-gallery')}
+                className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                  currentPage === 'public-gallery' || currentPage === 'flow-viewer'
+                    ? 'bg-blue-100 text-blue-700 border border-blue-200' 
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200 hover:text-gray-900'
+                }`}
+              >
+                Gallery
               </button>
               {user && (
                 <button 

--- a/src/components/PublicGallery.tsx
+++ b/src/components/PublicGallery.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect } from 'react'
+import { Flow, FlowStep, db, id } from '../lib/instant'
+import { useAuth } from './AuthProvider'
+import { useToast } from './ToastProvider'
+
+interface PublicGalleryProps {
+  onViewFlow: (flowId: string) => void
+}
+
+export function PublicGallery({ onViewFlow }: PublicGalleryProps) {
+  const { user } = useAuth()
+  const { showToast } = useToast()
+  const [flows, setFlows] = useState<Flow[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  // Load public flows from InstantDB
+  const { isLoading: dbLoading, data } = db.useQuery({
+    flows: {
+      $: {
+        where: {
+          isPublic: true
+        }
+      }
+    }
+  })
+
+  useEffect(() => {
+    if (!dbLoading && data?.flows) {
+      // Sort by most recently updated first
+      const sortedFlows = (data.flows as Flow[]).sort((a, b) => b.updatedAt - a.updatedAt)
+      setFlows(sortedFlows)
+      setIsLoading(false)
+    }
+  }, [dbLoading, data])
+
+  const getFlowPreview = (stepsData: string) => {
+    try {
+      const steps = JSON.parse(stepsData) as FlowStep[]
+      return steps.map(step => step.pose.name).join(' → ')
+    } catch {
+      return 'Invalid flow data'
+    }
+  }
+
+  const getFlowLength = (stepsData: string) => {
+    try {
+      const steps = JSON.parse(stepsData) as FlowStep[]
+      return `${steps.length} poses`
+    } catch {
+      return 'Unknown'
+    }
+  }
+
+  const copyFlow = async (flow: Flow) => {
+    if (!user) {
+      showToast('Please sign in to copy flows', 'error')
+      return
+    }
+
+    try {
+      await db.transact(
+        db.tx.flows[id()].update({
+          name: `Copy of ${flow.name}`,
+          description: flow.description ? `${flow.description} (copied)` : 'Copied from public gallery',
+          isPublic: false,
+          userId: user.id,
+          stepsData: flow.stepsData,
+          createdAt: Date.now(),
+          updatedAt: Date.now()
+        })
+      )
+      showToast(`Copied "${flow.name}" to your flows!`, 'success')
+    } catch (error) {
+      console.error('Error copying flow:', error)
+      showToast('Failed to copy flow. Please try again.', 'error')
+    }
+  }
+
+  const shareFlow = (flow: Flow) => {
+    const shareUrl = `${window.location.origin}/flow/${flow.id}`
+    navigator.clipboard.writeText(shareUrl).then(() => {
+      showToast('Flow link copied to clipboard!', 'success')
+    }).catch(() => {
+      showToast('Failed to copy to clipboard. Check console for link.', 'error')
+      console.log('Flow link:', shareUrl)
+    })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="max-w-7xl mx-auto p-6">
+        <div className="text-center py-12">
+          <div className="text-gray-400 text-4xl mb-4">⏳</div>
+          <p className="text-gray-600">Loading public flows...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto p-4 sm:p-6">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">Public Gallery</h1>
+        <p className="text-gray-600">
+          Discover acroyoga flows shared by the community. Click any flow to practice it, or copy it to your collection.
+        </p>
+      </div>
+
+      {flows.length === 0 ? (
+        <div className="text-center py-12">
+          <div className="text-gray-400 text-4xl mb-4">🌟</div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">No public flows yet</h2>
+          <p className="text-gray-600">Be the first to share a flow with the community!</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {flows.map((flow) => (
+            <div key={flow.id} className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hover:shadow-md transition-shadow">
+              <div className="p-6">
+                <div className="mb-4">
+                  <div className="flex items-start justify-between mb-2">
+                    <h3 className="font-bold text-gray-900 text-lg">{flow.name}</h3>
+                    <span className="px-2 py-1 text-xs bg-green-100 text-green-800 rounded-full">
+                      Public
+                    </span>
+                  </div>
+                  
+                  {flow.description && (
+                    <p className="text-gray-600 text-sm mb-3">{flow.description}</p>
+                  )}
+                  
+                  <p className="text-gray-500 text-sm mb-2">
+                    {getFlowPreview(flow.stepsData)}
+                  </p>
+                  
+                  <div className="flex items-center justify-between text-xs text-gray-400">
+                    <span>{getFlowLength(flow.stepsData)}</span>
+                    <span>Updated: {new Date(flow.updatedAt).toLocaleDateString()}</span>
+                  </div>
+                </div>
+
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => onViewFlow(flow.id)}
+                    className="flex-1 px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+                  >
+                    Practice Flow
+                  </button>
+                  
+                  <button
+                    onClick={() => shareFlow(flow)}
+                    className="px-3 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors text-sm"
+                    title="Share flow"
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/>
+                      <polyline points="16,6 12,2 8,6"/>
+                      <line x1="12" y1="2" x2="12" y2="15"/>
+                    </svg>
+                  </button>
+                  
+                  {user && (
+                    <button
+                      onClick={() => copyFlow(flow)}
+                      className="px-3 py-2 bg-green-100 text-green-700 rounded-lg hover:bg-green-200 transition-colors text-sm"
+                      title="Copy to my flows"
+                    >
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                      </svg>
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {/* Gradient bottom border */}
+              <div className="h-1 bg-gradient-to-r from-green-400 to-blue-600" />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Add comprehensive public gallery and flow viewer system

## Summary
Implements a complete public gallery system that allows users to discover, view, and practice acroyoga flows shared by the community.

### Key Features Added

#### Public Gallery (/gallery)
- Displays all public flows from the community
- Shows flow preview, description, length, and last updated date
- Share and copy functionality for each flow
- Copy feature only available to logged-in users
- Clean card-based layout with green/blue gradient borders

#### Flow Viewer (/flow/:id)
- Dedicated read-only flow practice mode
- Step-by-step navigation with Previous/Next buttons
- Progress bar showing current position in flow
- Current pose display with full details and transitions
- Flow overview sidebar with clickable step navigation
- Share and copy flow functionality
- Proper error handling for missing/private flows

#### URL Routing System
- /gallery - Public gallery of community flows
- /flow/:id - Individual flow viewer for practice
- Maintains backward compatibility with existing ?shared= URLs
- Proper browser history management with pushState

#### Updated Flow Sharing
- Changed from query-based URLs (?shared=id) to clean paths (/flow/id)
- Updated FlowsGallery share button to use new URL format
- Better UX with dedicated public flow URLs

### Navigation Updates
- Added Gallery button to both desktop and mobile headers
- Gallery button highlighted when viewing public gallery or individual flows
- Proper active state management across all pages

## Technical Implementation
- Two new components: PublicGallery and FlowViewer
- Enhanced App.tsx routing logic with URL path detection
- Proper state management for flow viewing and navigation
- Real-time data loading from InstantDB with public flow filtering
- Copy functionality generates new flow entries in user's private collection

## Test plan
- [x] Public gallery loads and displays empty state correctly
- [x] URL routing works for both /gallery and /flow/id paths
- [x] Navigation buttons work correctly with active states
- [x] Flow viewer properly handles non-existent flows
- [x] Error handling redirects users appropriately
- [x] TypeScript build passes without errors
- [x] Share URLs generate correct /flow/id format

## User Flow
1. User clicks Gallery button to view public flows
2. User sees list of community-shared flows
3. User clicks Practice Flow to open step-by-step viewer
4. User navigates through flow with Previous/Next or sidebar
5. Logged-in users can copy flows to their private collection
6. All users can share flows via direct URLs

Fixes #12