### PR TITLE
Fix flow editing save behavior - don't create new flow when editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ function App() {
     'builder' | 'gallery' | 'public-gallery' | 'flow-viewer' | 'about'
   >('builder');
   const [loadedFlow, setLoadedFlow] = useState<FlowStep[] | undefined>();
+  const [editingFlowId, setEditingFlowId] = useState<string | undefined>();
   const [viewingFlowId, setViewingFlowId] = useState<string | null>(null);
 
   // Check URL routing on app load
@@ -39,8 +40,9 @@ function App() {
     }
   }, []);
 
-  const handleLoadFlow = (flow: FlowStep[]) => {
+  const handleLoadFlow = (flow: FlowStep[], flowId?: string) => {
     setLoadedFlow(flow);
+    setEditingFlowId(flowId);
     setCurrentPage('builder');
     window.history.pushState({}, '', '/');
   };
@@ -53,6 +55,7 @@ function App() {
 
     if (page === 'builder') {
       setLoadedFlow(undefined); // Clear loaded flow when manually switching to builder
+      setEditingFlowId(undefined); // Clear editing flow ID
       window.history.pushState({}, '', '/');
     } else if (page === 'public-gallery') {
       window.history.pushState({}, '', '/gallery');
@@ -83,7 +86,10 @@ function App() {
           <Header currentPage={currentPage} onPageChange={handlePageChange} />
           <main>
             {currentPage === 'builder' ? (
-              <FlowBuilder initialFlow={loadedFlow} />
+              <FlowBuilder
+                initialFlow={loadedFlow}
+                editingFlowId={editingFlowId}
+              />
             ) : currentPage === 'gallery' ? (
               <FlowsGallery
                 onLoadFlow={handleLoadFlow}
@@ -104,7 +110,10 @@ function App() {
             ) : currentPage === 'about' ? (
               <AboutPage />
             ) : (
-              <FlowBuilder initialFlow={loadedFlow} />
+              <FlowBuilder
+                initialFlow={loadedFlow}
+                editingFlowId={editingFlowId}
+              />
             )}
           </main>
         </div>

--- a/src/components/FlowBuilder.tsx
+++ b/src/components/FlowBuilder.tsx
@@ -260,7 +260,7 @@ export function FlowBuilder({ initialFlow, editingFlowId }: FlowBuilderProps) {
               <button
                 onClick={handleSaveFlow}
                 disabled={
-                  currentFlow.length === 0 || (editingFlowId && !hasChanges())
+                  currentFlow.length === 0 || (!!editingFlowId && !hasChanges())
                 }
                 className="w-full flex items-center justify-center gap-2 px-4 py-3 sm:py-2 bg-gray-100 border border-gray-300 rounded-lg hover:bg-gray-200 transition-colors text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium min-h-[44px] sm:min-h-0"
               >

--- a/src/components/FlowSaveLoad.tsx
+++ b/src/components/FlowSaveLoad.tsx
@@ -17,7 +17,7 @@ interface SavedFlow {
 
 interface FlowSaveLoadProps {
   currentFlow: FlowStep[];
-  onLoadFlow: (flow: FlowStep[]) => void;
+  onLoadFlow: (flow: FlowStep[], flowId?: string) => void;
 }
 
 export function FlowSaveLoad({ currentFlow, onLoadFlow }: FlowSaveLoadProps) {

--- a/src/components/FlowViewer.tsx
+++ b/src/components/FlowViewer.tsx
@@ -7,7 +7,7 @@ import { PoseCard } from './PoseCard';
 interface FlowViewerProps {
   flowId: string;
   onBack: () => void;
-  onLoadFlow: (flow: FlowStep[]) => void;
+  onLoadFlow: (flow: FlowStep[], flowId?: string) => void;
 }
 
 export function FlowViewer({ flowId, onBack, onLoadFlow }: FlowViewerProps) {

--- a/src/components/FlowsGallery.tsx
+++ b/src/components/FlowsGallery.tsx
@@ -349,7 +349,7 @@ export function FlowsGallery({
                     onClick={() => handleLoadFlow(flow)}
                     className="px-3 py-2 bg-green-100 text-green-700 rounded-lg hover:bg-green-200 transition-colors text-sm font-medium"
                   >
-                    Load & Edit
+                    Edit
                   </button>
 
                   {flow.isPublic && (

--- a/src/components/FlowsGallery.tsx
+++ b/src/components/FlowsGallery.tsx
@@ -5,7 +5,7 @@ import { useToast } from './ToastProvider';
 import { ConfirmationModal } from './ConfirmationModal';
 
 interface FlowsGalleryProps {
-  onLoadFlow: (flow: FlowStep[]) => void;
+  onLoadFlow: (flow: FlowStep[], flowId?: string) => void;
   onPageChange: (page: 'builder' | 'gallery') => void;
   onPracticeFlow?: (flowId: string) => void;
 }
@@ -94,7 +94,7 @@ export function FlowsGallery({
   const handleLoadFlow = (flow: Flow) => {
     try {
       const steps = JSON.parse(flow.stepsData) as FlowStep[];
-      onLoadFlow(steps);
+      onLoadFlow(steps, flow.id); // Pass the flow ID for editing
       // Don't call onPageChange - onLoadFlow already handles page navigation
     } catch (error) {
       console.error('Error loading flow:', error);

--- a/src/components/PublicGallery.tsx
+++ b/src/components/PublicGallery.tsx
@@ -5,7 +5,7 @@ import { useToast } from './ToastProvider';
 
 interface PublicGalleryProps {
   onViewFlow: (flowId: string) => void;
-  onLoadFlow: (flow: FlowStep[]) => void;
+  onLoadFlow: (flow: FlowStep[], flowId?: string) => void;
 }
 
 export function PublicGallery({ onViewFlow, onLoadFlow }: PublicGalleryProps) {


### PR DESCRIPTION
## Summary
- Fixed: When editing an existing flow, save button now updates the existing flow instead of creating a new one
- Fixed: Save button is now disabled when no changes have been made to the flow
- Improved: Button text shows "Update flow" when editing vs "Save flow" when creating new

## Test plan
- [x] Load an existing flow for editing from "My flows" page
- [x] Verify save button shows "Update flow" and is initially disabled (no changes)
- [x] Add/remove poses to make changes and verify button becomes enabled
- [x] Click "Update flow" and verify it updates existing flow (doesn't create duplicate)
- [x] Verify form is pre-populated with existing flow data
- [x] Test creating new flows still works correctly

## Changes
- Add editingFlowId prop to FlowBuilder to track when editing existing flows
- Update FlowSaveModal to handle both create and update operations
- Add change tracking with originalFlow state to detect modifications
- Update button text and modal title to distinguish edit vs create
- Pre-populate form with existing flow data when editing
- Pass flow ID through component chain for proper editing context

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)