### PR TITLE
Fix alphabetical sorting of pose cards in gallery

### DIFF
--- a/src/components/PosesGallery.tsx
+++ b/src/components/PosesGallery.tsx
@@ -46,10 +46,12 @@ export function PosesGallery({ onViewPose }: PosesGalleryProps) {
 
   const allPoses = data?.poses || [];
 
-  // Apply favorites filtering
-  const poses = showOnlyFavorites
+  // Apply favorites filtering and sort alphabetically
+  const filteredPoses = showOnlyFavorites
     ? allPoses.filter(pose => isFavorited(pose.id))
     : allPoses;
+
+  const poses = filteredPoses.sort((a, b) => a.name.localeCompare(b.name));
 
   const getDifficultyColor = (difficulty: string) => {
     switch (difficulty) {


### PR DESCRIPTION
## Railway Deployment
https://acrokit-acrokit-pr-XX.up.railway.app

## Summary
- Add alphabetical sorting to the Poses Gallery page to ensure poses are displayed in alphabetical order by name
- Sorting applies to both the main gallery view and when filtering by difficulty level or favorites
- Uses `localeCompare()` for proper alphabetical sorting

## Test plan
- [x] Navigate to Poses Gallery page
- [x] Verify poses are displayed in alphabetical order (A-Z)
- [x] Test Easy filter - poses should remain alphabetically sorted
- [x] Test Medium filter - poses should remain alphabetically sorted  
- [x] Test Hard filter - poses should remain alphabetically sorted
- [x] Test favorites filter (if signed in) - poses should remain alphabetically sorted
- [x] Verify no broken layouts or visual issues
- [x] Run lint and build checks

fixes #51

🤖 Generated with [Claude Code](https://claude.ai/code)