### PR TITLE
Remove Practice Tips boxes from pose components

### DIFF
--- a/src/components/PoseDetail.tsx
+++ b/src/components/PoseDetail.tsx
@@ -159,15 +159,6 @@ export function PoseDetail({ poseId }: PoseDetailProps) {
               </p>
             </div>
 
-            {/* Tips Section - Placeholder for now */}
-            <div className="bg-blue-50 rounded-lg p-4 mb-6">
-              <h3 className="font-semibold text-blue-900 mb-2">💡 Tips</h3>
-              <p className="text-blue-800 text-sm">
-                Practice this pose with a qualified instructor. Focus on
-                communication and safety.
-              </p>
-            </div>
-
             {/* Other Names Section - Placeholder for now */}
             <div className="mb-6">
               <h3 className="font-semibold text-gray-900 mb-2">

--- a/src/components/PoseDetailModal.tsx
+++ b/src/components/PoseDetailModal.tsx
@@ -150,19 +150,6 @@ export function PoseDetailModal({
               {pose.description || 'No description available for this pose.'}
             </p>
           </div>
-
-          {/* Safety Tips */}
-          <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-            <h3 className="text-lg font-semibold text-blue-900 mb-2">
-              💡 Practice Tips
-            </h3>
-            <ul className="text-blue-800 text-sm space-y-2">
-              <li>• Always have a spotter when attempting new poses</li>
-              <li>• Communicate clearly with your partner throughout</li>
-              <li>• Start slowly and build up to the full expression</li>
-              <li>• Listen to your body and don&apos;t force positions</li>
-            </ul>
-          </div>
         </div>
 
         {/* Footer */}


### PR DESCRIPTION
## Railway Deployment
https://acrokit-acrokit-pr-XX.up.railway.app

## Summary
- Remove the generic "Practice Tips" boxes from PoseDetail and PoseDetailModal components
- Clean up the UI by removing blue-styled tip sections with hardcoded safety tips
- Layout now flows cleanly from description to other sections

## Changes Made
- **PoseDetail.tsx**: Removed "💡 Tips" section with placeholder safety guidance
- **PoseDetailModal.tsx**: Removed "💡 Practice Tips" section with hardcoded safety tips list

## Test plan
- [x] Navigate to Poses Gallery and click on a pose to view detail page
- [x] Verify Practice Tips section is no longer present in PoseDetail view
- [x] Navigate to Flow Builder and click "View Details" on a pose
- [x] Verify Practice Tips section is no longer present in PoseDetailModal
- [x] Confirm layout flows properly from description to other sections
- [x] Verify no broken layouts or visual issues
- [x] Run lint and build checks

fixes #52

🤖 Generated with [Claude Code](https://claude.ai/code)