### PR TITLE
Add database backing for "Also Known As" pose feature

### DIFF
--- a/src/components/PoseDetail.tsx
+++ b/src/components/PoseDetail.tsx
@@ -159,17 +159,24 @@ export function PoseDetail({ poseId }: PoseDetailProps) {
               </p>
             </div>
 
-            {/* Other Names Section - Placeholder for now */}
-            <div className="mb-6">
-              <h3 className="font-semibold text-gray-900 mb-2">
-                🏷️ Also Known As
-              </h3>
-              <div className="flex flex-wrap gap-2">
-                <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded text-sm">
-                  {pose.name}
-                </span>
+            {/* Also Known As Section */}
+            {pose.alsoKnownAs && pose.alsoKnownAs.length > 0 && (
+              <div className="mb-6">
+                <h3 className="font-semibold text-gray-900 mb-2">
+                  🏷️ Also Known As
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {pose.alsoKnownAs.map((name: string, index: number) => (
+                    <span
+                      key={index}
+                      className="px-2 py-1 bg-gray-100 text-gray-700 rounded text-sm"
+                    >
+                      {name}
+                    </span>
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -14,6 +14,7 @@ export const schema = i.schema({
       name: i.string().indexed(),
       description: i.string(),
       difficulty: i.string(),
+      alsoKnownAs: i.json().optional(),
       isStartingPose: i.boolean().optional(),
       createdAt: i.date(),
     }),
@@ -104,6 +105,7 @@ export type Schema = {
     name: string;
     description: string;
     difficulty: 'Easy' | 'Medium' | 'Hard';
+    alsoKnownAs?: string[]; // Array of alternative names for the pose
     isStartingPose?: boolean;
     createdAt: string; // ISO date string like "2025-07-07T20:50:38.091Z"
   };


### PR DESCRIPTION
## Railway Deployment
https://acrokit-acrokit-pr-XX.up.railway.app

## Summary
- Add database backing for the "Also Known As" feature for poses
- Implement complete end-to-end functionality from database schema to UI
- Replace placeholder UI with actual data-driven implementation

## Changes Made

### Database Schema
- **Added `alsoKnownAs` field** to Pose entity as optional JSON array using InstantDB schema
- **Updated TypeScript types** to include `alsoKnownAs?: string[]` in Pose interface  
- **Used InstantDB MCP tools** to push schema changes to production database

### Frontend Implementation  
- **Enhanced PoseDetail component** to use actual `alsoKnownAs` data instead of placeholder
- **Added conditional rendering** - "Also Known As" section only appears when pose has alternative names
- **Proper type safety** with TypeScript compliance for map function parameters
- **Graceful fallback** - section hidden when no alternative names exist

### Technical Details
- Uses `i.json().optional()` type in InstantDB schema for array storage
- Implements proper null/undefined checking before rendering
- Maintains existing UI design and styling
- Backwards compatible - existing poses without data work seamlessly

## Test plan
- [x] Navigate to Poses Gallery and click on a pose to view detail page
- [x] Verify "Also Known As" section is hidden for poses without alternative names
- [x] Confirm schema changes deployed successfully to InstantDB
- [x] Validate TypeScript types are correct and compile successfully
- [x] Test responsive design and UI layout integrity
- [x] Run lint and build checks
- [x] Verify existing functionality remains unaffected

## Future Usage
Once merged, poses can have alternative names added to the database using:
```typescript
db.transact(db.tx.poses[poseId].update({ 
  alsoKnownAs: ["Alternative Name 1", "Alternative Name 2"] 
}))
```

fixes #53

🤖 Generated with [Claude Code](https://claude.ai/code)